### PR TITLE
Adding jsx and sass extensions to webpack loader config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,8 @@ module.exports = {
   ],
   module: {
     loaders: [
-      { test: /\.js?$/, loader: 'babel', exclude: /node_modules/ },
-      { test: /\.s?css$/, loader: 'style!css!sass' },
+      { test: /\.jsx?$/, loader: 'babel', exclude: /node_modules/ },
+      { test: /\.(c|sc|sa)ss$/, loader: 'style!css!sass' },
     ]
   },
   resolve: {


### PR DESCRIPTION
I've notice that the sass loader's regex was not matching.sass extension, and the js loader was matching .j instead of .jsx

I'm new to webpack tho so I might be wrong or not understanding some concepts